### PR TITLE
Added dependency 'flask-alembic', it is not available on PyPI.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ Flask-Script
 https://github.com/hasgeek/coaster/zipball/master
 https://github.com/hasgeek/flask-lastuser/zipball/master
 https://github.com/hasgeek/baseframe/zipball/master
+https://github.com/jace/flask-alembic/zipball/master


### PR DESCRIPTION
- Required as we are using 'flask.ext.alembic'
- See also https://github.com/tobiasandtobias/flask-alembic/issues/7
