### PR TITLE
removes duplicate entry from requirements.txt for 'bleach'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ jsmin
 dnspython
 html2text
 premailer
-bleach
 langid
 Flask-Script==0.5.3
 https://github.com/hasgeek/coaster/zipball/master


### PR DESCRIPTION
I was installing dependencies then it raised me following error, for a duplicate entry in the file.

> Double requirement given: bleach (from -r requirements.txt (line 22)) (already in bleach (from -r requirements.txt (line 16)), name='bleach')

I am using `pip` version `1.3.1`

So this commit removes that duplicate entry.
