### PR TITLE
remove dangling unrot reference. 

### DIFF
--- a/hasjob/templates/detail.html
+++ b/hasjob/templates/detail.html
@@ -320,7 +320,6 @@
       $(this).attr('disabled', 'disabled');
       $.ajax($(this).attr('href')).done(function(html) {
         $("#apply-info-para").html(html);
-        unrot13();
         {%- if applyform %}
           $("#apply-section").removeClass('hidden');
         {%- endif %}


### PR DESCRIPTION
![hj_broken_ajax_apply_form](https://cloud.githubusercontent.com/assets/380688/5060450/c9924e18-6d7b-11e4-9741-ca9ec7d0983b.png)

The dangling reference to unrot13 was preventing the application form from loading completely. Removing the reference fixes the bug.
