### PR TITLE
Tweaked CSS class .stickie .bottom-right CSS to 70%

### DIFF
--- a/hasjob/static/css/app.css
+++ b/hasjob/static/css/app.css
@@ -934,7 +934,7 @@ tr > div {
 .stickie .bottom-right {
   right: 0.5em;
   bottom: 0.1em;
-  width: 75%;
+  width: 70%;
   text-align: right;
 }
 .stickie .bottom-left {

--- a/hasjob/static/sass/_stickie.sass
+++ b/hasjob/static/sass/_stickie.sass
@@ -60,7 +60,7 @@
   .bottom-right
     right: 0.5em
     bottom: 0.1em
-    width: 75%
+    width: 70%
     text-align: right
 
   .bottom-left


### PR DESCRIPTION
Now, the annotations ("new" and company name) on job stickies are visibly
separate despite the length of the company name on both Google Chrome and
Safari. Previously this wasn't the case.

Tested for said behaviour before and after tweak on
Chrome (45.0.2454.101 (64-bit)) and Safari (Version 9.0 (11601.1.56)).