### PR TITLE
Update .gitignore to include Virutalenv's dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ baseframe-packed.css
 editor.packed.css
 uploads/
 search/
+venv/
 hasjob/static/gen
 *.sql
 *.gz


### PR DESCRIPTION
Since we recommend to use Virtualenv in our Installation instructions,
added "venv/" to .gitignore.