### PR TITLE
Endless pagination

### DIFF
--- a/hasjob/__init__.py
+++ b/hasjob/__init__.py
@@ -51,7 +51,7 @@ def init_for(env):
 
     baseframe.init_app(app, requires=['hasjob'],
         ext_requires=['baseframe-bs3',
-            ('jquery.autosize', 'jquery.sparkline', 'jquery.liblink', 'jquery.wnumb', 'jquery.nouislider', 'jquery.appear'),
+            ('jquery.autosize', 'jquery.sparkline', 'jquery.liblink', 'jquery.wnumb', 'jquery.nouislider'),
             'baseframe-firasans', 'fontawesome>=4.3.0', 'bootstrap-multiselect', 'nprogress', 'ractive'],
         enable_csrf=True)
     # TinyMCE has to be loaded by itself, unminified, or it won't be able to find its assets

--- a/hasjob/__init__.py
+++ b/hasjob/__init__.py
@@ -52,7 +52,7 @@ def init_for(env):
     baseframe.init_app(app, requires=['hasjob'],
         ext_requires=['baseframe-bs3',
             ('jquery.autosize', 'jquery.sparkline', 'jquery.liblink', 'jquery.wnumb', 'jquery.nouislider'),
-            'baseframe-firasans', 'fontawesome>=4.3.0', 'bootstrap-multiselect', 'nprogress', 'ractive'],
+            'baseframe-firasans', 'fontawesome>=4.3.0', 'bootstrap-multiselect', 'nprogress', 'ractive', 'jquery.appear'],
         enable_csrf=True)
     # TinyMCE has to be loaded by itself, unminified, or it won't be able to find its assets
     app.assets.register('js_tinymce', assets.require('!jquery.js', 'tinymce.js>=4.0.0', 'jquery.tinymce.js>=4.0.0'))

--- a/hasjob/static/js/app.js
+++ b/hasjob/static/js/app.js
@@ -86,45 +86,55 @@ window.Hasjob.StickieList = {
   },
   loadmore: function(config){
     var stickielist = this;
-    if (!Hasjob.StickieList.hasOwnProperty('loadmoreRactive')) {
-      stickielist.loadmoreRactive = new Ractive({
-        el: 'loadmore',
-        template: '#loadmore-ractive',
-        data: {
-          error: false,
-          loading: false,
-          url: config.url
-        }
-      });
-
-      var shouldLoad = function(){
-        return (
-          stickielist.loadmoreRactive.get('url') !== '' &&
-          Hasjob.Util.isElementVisible('loadmore') &&
-          !stickielist.loadmoreRactive.get('loading')
-        );
-      };
-
-      var load = function(){
-        if (shouldLoad()){
-          stickielist.loadmoreRactive.set('loading', true);
-          $.ajax(stickielist.loadmoreRactive.get('url'), {
-            success: function(data) {
-              $('ul#stickie-area').append(data.trim());
-              stickielist.loadmoreRactive.set('loading', false);
-              stickielist.loadmoreRactive.set('error', false);
-            },
-            error: function(context, xhr, status, errMsg) {
-              stickielist.loadmoreRactive.set('error', true);
-              stickielist.loadmoreRactive.set('loading', false);
-            }
-          });
-        }
-      };
-      window.setInterval(load, 500);
+    if (!config.enable) {
+      // Hide template
+      this.loadmoreRactive.set('url', '');
     } else {
-      this.loadmoreRactive.set('url', config.url);
+      if (!config.paginated) {
+        // Initial render
+        stickielist.loadmoreRactive = new Ractive({
+          el: 'loadmore',
+          template: '#loadmore-ractive',
+          data: {
+            error: false,
+            loading: false,
+            url: config.url
+          }
+        });
+
+        var shouldLoad = function(){
+          return (
+            stickielist.loadmoreRactive.get('url') !== '' &&
+            Hasjob.Util.isElementVisible('loadmore') &&
+            !stickielist.loadmoreRactive.get('loading')
+          );
+        };
+
+        var load = function(){
+          if (shouldLoad()){
+            stickielist.loadmoreRactive.set('loading', true);
+            $.ajax(stickielist.loadmoreRactive.get('url'), {
+              success: function(data) {
+                $('ul#stickie-area').append(data.trim());
+                stickielist.loadmoreRactive.set('loading', false);
+                stickielist.loadmoreRactive.set('error', false);
+              },
+              error: function(context, xhr, status, errMsg) {
+                stickielist.loadmoreRactive.set('error', true);
+                stickielist.loadmoreRactive.set('loading', false);
+              }
+            });
+          }
+        };
+        window.setInterval(load, 500);
+      } else {
+        // Update rendered template
+        this.loadmoreRactive.set('url', config.url);
+      }
     }
+  },
+  update: function(config){
+    this.loadmoreRactive.set('url', config.url);
   },
   refresh: function(){
     // progress indicator

--- a/hasjob/static/js/app.js
+++ b/hasjob/static/js/app.js
@@ -97,7 +97,6 @@ window.Hasjob.StickieList = {
           error: function() {
             stickielist.loadmoreRactive.set('error', true);
             stickielist.loadmoreRactive.set('loading', false);
-            // window.clearInterval(stickielist.loader);
           }
         });
       }
@@ -106,7 +105,6 @@ window.Hasjob.StickieList = {
     if (!config.enable) {
       // Hide template
       this.loadmoreRactive.set('enable', config.enable);
-      // window.clearInterval(stickielist.loader);
     } else {
       if (!config.paginated) {
         // Initial render

--- a/hasjob/static/js/app.js
+++ b/hasjob/static/js/app.js
@@ -138,7 +138,11 @@ window.Hasjob.StickieList = {
     // progress indicator
     NProgress.configure({ showSpinner: false });
     NProgress.start();
-    var searchUrl = window.Hasjob.Config.baseURL + '?' + window.Hasjob.Filters.toParam();
+    var filterParams = window.Hasjob.Filters.toParam();
+    var searchUrl = window.Hasjob.Config.baseURL;
+    if (filterParams.length) {
+      var searchUrl = window.Hasjob.Config.baseURL + '?' + window.Hasjob.Filters.toParam();
+    }
     $.ajax(searchUrl, {
       method: 'POST',
       headers: {

--- a/hasjob/static/js/app.js
+++ b/hasjob/static/js/app.js
@@ -81,7 +81,7 @@ window.Hasjob.JobPost = {
 };
 
 window.Hasjob.StickieList = {
-  init: function(config){
+  init: function(){
     var stickielist = this;
   },
   loadmore: function(config){
@@ -132,9 +132,6 @@ window.Hasjob.StickieList = {
         this.loadmoreRactive.set('url', config.url);
       }
     }
-  },
-  update: function(config){
-    this.loadmoreRactive.set('url', config.url);
   },
   refresh: function(){
     // progress indicator

--- a/hasjob/static/js/app.js
+++ b/hasjob/static/js/app.js
@@ -81,55 +81,50 @@ window.Hasjob.JobPost = {
 };
 
 window.Hasjob.StickieList = {
-  urlFor: function(timestamp){
-    var params = window.Hasjob.Filters.toParam();
-    var url = window.Hasjob.Config.baseURL + '?' + 'startdate=' + timestamp;
-    if (params !== '') {
-      return url + '&' + params;
-    }
-    return url;
-  },
   init: function(config){
     var stickielist = this;
-
-    if (config.paginate) {
-      stickielist.loadmore = new Ractive({
+  },
+  loadmore: function(config){
+    var stickielist = this;
+    if (!Hasjob.StickieList.hasOwnProperty('loadmoreRactive')) {
+      stickielist.loadmoreRactive = new Ractive({
         el: 'loadmore',
         template: '#loadmore-ractive',
         data: {
           error: false,
           loading: false,
-          timestamp: config.timestamp,
-          paginate: config.paginate
+          url: config.url
         }
       });
 
-      var shouldPaginate = function(){
-        return stickielist.loadmore.get('paginate') && Hasjob.Util.isElementVisible('loadmore') && !stickielist.loadmore.get('loading');
+      var shouldLoad = function(){
+        return (
+          stickielist.loadmoreRactive.get('url') !== '' &&
+          Hasjob.Util.isElementVisible('loadmore') &&
+          !stickielist.loadmoreRactive.get('loading')
+        );
       };
 
-      var paginatePosts = function(){
-        if (shouldPaginate()){
-          stickielist.loadmore.set('loading', true);
-          $.ajax(stickielist.urlFor(stickielist.loadmore.get('timestamp')), {
+      var load = function(){
+        if (shouldLoad()){
+          stickielist.loadmoreRactive.set('loading', true);
+          $.ajax(stickielist.loadmoreRactive.get('url'), {
             success: function(data) {
               $('ul#stickie-area').append(data.trim());
-              stickielist.loadmore.set('loading', false);
-              stickielist.loadmore.set('error', false);
+              stickielist.loadmoreRactive.set('loading', false);
+              stickielist.loadmoreRactive.set('error', false);
             },
             error: function(context, xhr, status, errMsg) {
-              stickielist.loadmore.set('error', true);
-              stickielist.loadmore.set('loading', false);
+              stickielist.loadmoreRactive.set('error', true);
+              stickielist.loadmoreRactive.set('loading', false);
             }
           });
         }
       };
-      window.setInterval(paginatePosts, 500);
+      window.setInterval(load, 500);
+    } else {
+      this.loadmoreRactive.set('url', config.url);
     }
-  },
-  paginate: function(config){
-    this.loadmore.set('timestamp', config.timestamp);
-    this.loadmore.set('paginate', config.paginate);
   },
   refresh: function(){
     // progress indicator

--- a/hasjob/static/js/app.js
+++ b/hasjob/static/js/app.js
@@ -119,7 +119,7 @@ window.Hasjob.StickieList = {
           }
         });
 
-        stickielist.loadmoreRactive.on( 'forceload', function ( event ) {
+        stickielist.loadmoreRactive.on('forceload', function(event) {
           load();
         });
 

--- a/hasjob/templates/index.html
+++ b/hasjob/templates/index.html
@@ -178,15 +178,14 @@
           <div class="row" id='loadmore'>
             {%- raw %}
             <script id='loadmore-ractive' type='text/ractive'>
-              {{#if error}}
-                <div class="alert alert-danger fade in"><a href="#" class="close" data-dismiss="alert">&times;</a> Could not load more posts. Please try again.</div>
-              {{ else }}
-                {{#if url !== ''}}
-                  {{#if loading}}
-                    <a disabled="disabled" href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Loading more…<span class="loading">&nbsp;</span></a>
-                  {{else}}
-                    <a href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Load more…</a>
-                  {{/if}}
+              {{#if enable}}
+                {{#if error}}
+                  <div class="alert alert-danger fade in"><a href="#" class="close" data-dismiss="alert">&times;</a> Could not load more posts. Please try again.</div>
+                {{/if}}
+                {{#if loading}}
+                  <a disabled="disabled" href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Loading more…<span class="loading">&nbsp;</span></a>
+                {{else}}
+                  <a href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate" on-click="forceload">Load more…</a>
                 {{/if}}
               {{/if}}
             </script>
@@ -217,7 +216,7 @@
           enable: true,
           paginated: paginated
         });
-      } else if (paginated) {
+      } else {
         window.Hasjob.StickieList.loadmore({enable: false});
       }
     });

--- a/hasjob/templates/index.html
+++ b/hasjob/templates/index.html
@@ -178,14 +178,15 @@
           <div class="row" id='loadmore'>
             {%- raw %}
             <script id='loadmore-ractive' type='text/ractive'>
-              {{#if url !== ''}}
-                {{#if loading}}
-                  <a disabled="disabled" href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Loading more…<span class="loading">&nbsp;</span></a>
-                {{else}}
-                  <a href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Load more…</a>
-                {{/if}}
-                {{#if error}}
-                  <div class="alert alert-danger fade in"><a href="#" class="close" data-dismiss="alert">&times;</a> Could not load more posts. Please try again.</div>
+              {{#if error}}
+                <div class="alert alert-danger fade in"><a href="#" class="close" data-dismiss="alert">&times;</a> Could not load more posts. Please try again.</div>
+              {{ else }}
+                {{#if url !== ''}}
+                  {{#if loading}}
+                    <a disabled="disabled" href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Loading more…<span class="loading">&nbsp;</span></a>
+                  {{else}}
+                    <a href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Load more…</a>
+                  {{/if}}
                 {{/if}}
               {{/if}}
             </script>

--- a/hasjob/templates/index.html
+++ b/hasjob/templates/index.html
@@ -168,23 +168,30 @@
     {%- if not paginated -%}
     </ul>
     {%- endif -%}
-    {%- if loadmore and not paginated -%}
-      <div class="row" id='loadmore'>
-      {%- raw %}
-      <script id='loadmore-ractive' type='text/ractive'>
-        {{#if paginate}}
-          {{#if loading}}
-            <a disabled="disabled" href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Loading more…<span class="loading">&nbsp;</span></a>
-          {{else}}
-            <a href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Load more…</a>
-          {{/if}}
-          {{#if error}}
-            <div class="alert alert-danger fade in"><a href="#" class="close" data-dismiss="alert">&times;</a> Could not load more posts. Please try again.</div>
-          {{/if}}
-        {{/if}}
-      </script>
-      {%- endraw %}
-      </div>
+    {%- if loadmore -%}
+        <noscript>
+          <div class="row text-center">
+            <a href="{{url_for('index', **format_args(loadmore)) | safe}}" class="btn btn-default btn-lg" name="startdate">Load more…</a>
+          </div>
+        </noscript>
+        {%- if not paginated -%}
+          <div class="row" id='loadmore'>
+            {%- raw %}
+            <script id='loadmore-ractive' type='text/ractive'>
+              {{#if url !== ''}}
+                {{#if loading}}
+                  <a disabled="disabled" href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Loading more…<span class="loading">&nbsp;</span></a>
+                {{else}}
+                  <a href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Load more…</a>
+                {{/if}}
+                {{#if error}}
+                  <div class="alert alert-danger fade in"><a href="#" class="close" data-dismiss="alert">&times;</a> Could not load more posts. Please try again.</div>
+                {{/if}}
+              {{/if}}
+            </script>
+            {%- endraw %}
+          </div>
+        {%- endif -%}
     {%- endif -%}
   {%- endwith %}
   {%- if not showall -%}
@@ -201,21 +208,13 @@
   <script type="text/javascript">
     $(function(){
       {%- if loadmore -%}
-        {%- if not paginated -%}
-          window.Hasjob.StickieList.init({
-            timestamp: '{{loadmore.isoformat()}}Z',
-            paginate: true
-          });
-        {%- else -%}
-          window.Hasjob.StickieList.paginate({
-            timestamp: '{{loadmore.isoformat()}}Z',
-            paginate: true
-          });
-        {%- endif -%}
+        window.Hasjob.StickieList.loadmore({
+          url: "{{url_for('index', **format_args(loadmore)) | safe}}"
+        });
       {%- else -%}
-          window.Hasjob.StickieList.init({
-            paginate: false
-          });
+        window.Hasjob.StickieList.loadmore({
+          url: ''
+        });
       {%- endif -%}
     });
   </script>

--- a/hasjob/templates/index.html
+++ b/hasjob/templates/index.html
@@ -135,7 +135,7 @@
           </li>
         {%- endfor -%}
       {%- endif -%}
-      {%- if grouped %}
+      {%- if grouped -%}
         {%- for grouping, group in grouped.items() -%}{%- with pinned, post, is_bgroup=group[0] -%}
           {%- if group|length == 1 -%}
             <li class="col-xs-12 col-md-3 col-sm-4">
@@ -152,7 +152,7 @@
                 {{ stickie(post, none, false, groupedunder=true, dataurl=post.url_for(b=is_bgroup), show_viewcounts=is_siteadmin or guser and guser.flags.is_employer_month, show_pay=is_siteadmin, starred=guser and post.id in gstarred_ids, is_bgroup=is_bgroup) }}
               {%- endfor -%}
             </li>
-          {%- endif %}
+          {%- endif -%}
         {%- endwith -%}{%- endfor -%}
       {%- else %}
         {%- for pinned, post, is_bgroup in pinsandposts -%}
@@ -165,20 +165,22 @@
           </li>
         {%- endfor -%}
       {%- endif -%}
-    {%- if not paginated %}
+    {%- if not paginated -%}
     </ul>
-    {%- endif %}
+    {%- endif -%}
     {%- if loadmore and not paginated -%}
       <div class="row" id='loadmore'>
       {%- raw %}
       <script id='loadmore-ractive' type='text/ractive'>
-        {{#if loadingBatch}}
-          <a id="loadmore-trigger" disabled="disabled" href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Loading more…<span class="loading">&nbsp;</span></a>
-        {{else}}
-          <a id="loadmore-trigger" href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Load more…</a>
-        {{/if}}
-        {{#if error}}
-          <div class="alert alert-danger fade in"><a href="#" class="close" data-dismiss="alert">&times;</a> Could not load more posts. Please try again</div>
+        {{#if paginate}}
+          {{#if loading}}
+            <a disabled="disabled" href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Loading more…<span class="loading">&nbsp;</span></a>
+          {{else}}
+            <a href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Load more…</a>
+          {{/if}}
+          {{#if error}}
+            <div class="alert alert-danger fade in"><a href="#" class="close" data-dismiss="alert">&times;</a> Could not load more posts. Please try again.</div>
+          {{/if}}
         {{/if}}
       </script>
       {%- endraw %}
@@ -196,25 +198,27 @@
 {%- endblock -%}
 
 {%- block footerscripts -%}
-  {%- if loadmore -%}
-    {%- if not paginated -%}
-      <script type="text/javascript">
-        $(function() {
-          window.Hasjob.Loadmore.init({
-            timestamp: '{{loadmore.isoformat()}}Z'
+  <script type="text/javascript">
+    $(function(){
+      {%- if loadmore -%}
+        {%- if not paginated -%}
+          window.Hasjob.StickieList.init({
+            timestamp: '{{loadmore.isoformat()}}Z',
+            paginate: true
           });
-        });
-      </script>
-    {%- else -%}
-      <script type="text/javascript">
-        $(function() {
-          window.Hasjob.Loadmore.update({
-            timestamp: '{{loadmore.isoformat()}}Z'
+        {%- else -%}
+          window.Hasjob.StickieList.paginate({
+            timestamp: '{{loadmore.isoformat()}}Z',
+            paginate: true
           });
-        });
-    </script>
-    {%- endif -%}
-  {%- endif -%}
+        {%- endif -%}
+      {%- else -%}
+          window.Hasjob.StickieList.init({
+            paginate: false
+          });
+      {%- endif -%}
+    });
+  </script>
   {%- if not paginated -%}
     {% from "macros.html" import filters_setup_script %}
     {%- if request.is_xhr -%}

--- a/hasjob/templates/index.html
+++ b/hasjob/templates/index.html
@@ -171,7 +171,7 @@
     {%- if loadmore -%}
         <noscript>
           <div class="row text-center">
-            <a href="{{url_for('index', **format_args(loadmore)) | safe}}" class="btn btn-default btn-lg" name="startdate">Load more…</a>
+            <a href="{{url_for('index', **query_params) | safe}}" class="btn btn-default btn-lg" name="startdate">Load more…</a>
           </div>
         </noscript>
         {%- if not paginated -%}
@@ -207,15 +207,18 @@
 {%- block footerscripts -%}
   <script type="text/javascript">
     $(function(){
-      {%- if loadmore -%}
+      var loadmore = {{loadmore | tojson}};
+      var paginated = {{paginated | tojson}};
+      var loadmoreURL = "{{url_for('index', **query_params) | safe}}";
+      if (loadmore){
         window.Hasjob.StickieList.loadmore({
-          url: "{{url_for('index', **format_args(loadmore)) | safe}}"
+          url: loadmoreURL,
+          enable: true,
+          paginated: paginated
         });
-      {%- else -%}
-        window.Hasjob.StickieList.loadmore({
-          url: ''
-        });
-      {%- endif -%}
+      } else if (paginated) {
+        window.Hasjob.StickieList.loadmore({enable: false});
+      }
     });
   </script>
   {%- if not paginated -%}

--- a/hasjob/templates/index.html
+++ b/hasjob/templates/index.html
@@ -182,39 +182,14 @@
   {%- endif -%}
 {%- endblock -%}
 
-{%- macro loadmore_script() -%}
-  <script type="text/javascript">
-    $(function() {
-      $("#loadmore").attr('method', 'POST').ajaxForm({
-        dataType: 'html',
-        beforeSubmit: function(formdata, form, options) {
-          form.find('button[type="submit"]').prop('disabled', true).addClass('submit-disabled').html('Loading more… <span class="loading">&nbsp;</span>');
-          return true;
-        },
-        success: function(responseText, statusText, xhr, form) {
-          target = $("#loadmore").replaceWith(responseText.trim());
-        },
-        error: function(context, xhr, status, errMsg) {
-          var form = $("#loadmore");
-          form.find('button[type="submit"]').prop('disabled', false).removeClass('submit-disabled').html('Load more…');
-          form.find('.loading').addClass('hidden');
-          form.append('<div class="alert alert-danger fade in"><a href="#" class="close" data-dismiss="alert">&times;</a> Could not load more posts. Please try again</div>');
-        }
-      });
-      $("#loadmore").appear().on('appear', function(event, element) {
-        element.find('button[type="submit"]').trigger('click');
-      });
-    });
-  </script>
-{%- endmacro -%}
 {%- block footerscripts -%}
   {% from "macros.html" import filters_setup_script %}
   {%- if request.is_xhr and not paginated -%}
     {{ filters_setup_script(job_location_filters, job_type_filters, job_category_filters) }}
   {%- endif %}
   <script type="text/javascript">
-
     {%- if not paginated -%}
+    window.Hasjob.index();
     //For setting the pay slider
     window.Hasjob.PayFilterParameters = {
       'currency': {{ request.args.get('currency') | tojson }},
@@ -283,7 +258,4 @@
       });
     </script>
   {%- endif %}
-  {%- if loadmore -%}
-    {{ loadmore_script() }}
-  {%- endif -%}
 {% endblock %}

--- a/hasjob/templates/index.html
+++ b/hasjob/templates/index.html
@@ -165,12 +165,25 @@
           </li>
         {%- endfor %}
       {%- endif -%}
-      {%- if loadmore -%}
-        <form id="loadmore" method="GET" data-appear-top-offset="600">
-          <button class="btn btn-default btn-lg" type="submit" name="startdate" value="{{ loadmore.isoformat() }}Z">Load more…</button>
-        </form>
-      {%- endif -%}
+    {%- if not paginated %}
     </ul>
+    {%- endif %}
+    {%- if loadmore and not paginated -%}
+      <div class="row" id='loadmore'>
+      {%- raw %}
+      <script id='loadmore-ractive' type='text/ractive'>
+        {{#if loadingBatch}}
+          <a id="loadmore-trigger" disabled="disabled" href="{{nextPagePath}}" class="btn btn-default btn-lg" name="startdate">Loading more…<span class="loading">&nbsp;</span></a>
+        {{else}}
+          <a id="loadmore-trigger" href="{{nextPagePath}}" class="btn btn-default btn-lg" name="startdate">Load more…</a>
+        {{/if}}
+        {{#if error}}
+          <div class="alert alert-danger fade in"><a href="#" class="close" data-dismiss="alert">&times;</a> Could not load more posts. Please try again</div>
+        {{/if}}
+      </script>
+      {%- endraw %}
+      </div>
+    {%- endif -%}
   {%- endwith %}
   {%- if not showall -%}
     <div class="flash info">
@@ -183,36 +196,44 @@
 {%- endblock -%}
 
 {%- block footerscripts -%}
-  {% from "macros.html" import filters_setup_script %}
-  {%- if request.is_xhr and not paginated -%}
-    {{ filters_setup_script(job_location_filters, job_type_filters, job_category_filters) }}
-  {%- endif %}
-  <script type="text/javascript">
-    {%- if not paginated -%}
-    window.Hasjob.index();
-    //For setting the pay slider
-    window.Hasjob.PayFilterParameters = {
-      'currency': {{ request.args.get('currency') | tojson }},
-      'pmin': {{ request.args.get('pmin') | tojson }},
-      'pmax': {{ request.args.get('pmax') | tojson }}
-    };
-    {%- endif %}
-
-    $(function() {
-      $('textarea').autosize();
-      $("#newpost_details").hide().removeClass('jshidden');
-      $("#newpost_headline").focus(function() {
-        $("#newpost_details").slideDown();
-      }).keypress(function(event) {
-        if(event.which == '13') {
-          $(this).closest("form").submit();
-          return false;
-        }
-      }).blur(function() {
-        $(this).val($(this).val().replace(/(\r\n|\n|\r)/gm," ").replace(/\s+/g," "));
+  {%- if loadmore and paginated %}
+    <script type="text/javascript">
+      window.Hasjob.Loadmore.update({
+        nextPagePath: '{{request.path + '?' + 'startdate=' + loadmore.isoformat() + 'Z' + '&' + request.query_string if loadmore else False}}'
       });
-    });
-  </script>
+    </script>
+  {%- endif %}
+  {%- if not paginated -%}
+    {% from "macros.html" import filters_setup_script %}
+    {%- if request.is_xhr -%}
+      {{ filters_setup_script(job_location_filters, job_type_filters, job_category_filters) }}
+    {%- endif %}
+    <script type="text/javascript">
+      $(function() {
+        window.Hasjob.Loadmore.init({
+          nextPagePath: '{{request.path + '?' + 'startdate=' + loadmore.isoformat() + 'Z' + '&' + request.query_string if loadmore else False}}'
+        });
+        //For setting the pay slider
+        window.Hasjob.PayFilterParameters = {
+          'currency': {{ request.args.get('currency') | tojson }},
+          'pmin': {{ request.args.get('pmin') | tojson }},
+          'pmax': {{ request.args.get('pmax') | tojson }}
+        };
+        $('textarea').autosize();
+        $("#newpost_details").hide().removeClass('jshidden');
+        $("#newpost_headline").focus(function() {
+          $("#newpost_details").slideDown();
+        }).keypress(function(event) {
+          if(event.which == '13') {
+            $(this).closest("form").submit();
+            return false;
+          }
+        }).blur(function() {
+          $(this).val($(this).val().replace(/(\r\n|\n|\r)/gm," ").replace(/\s+/g," "));
+        });
+      });
+    </script>
+  {%- endif %}
   {%- if pay_graph_data and not paginated %}
     <script type="text/javascript">
       c3.generate({

--- a/hasjob/templates/index.html
+++ b/hasjob/templates/index.html
@@ -163,7 +163,7 @@
           <li class="col-xs-12 col-md-3 col-sm-4">
             <span class="stickie special">Sorry, no jobs listed.</span>
           </li>
-        {%- endfor %}
+        {%- endfor -%}
       {%- endif -%}
     {%- if not paginated %}
     </ul>
@@ -173,9 +173,9 @@
       {%- raw %}
       <script id='loadmore-ractive' type='text/ractive'>
         {{#if loadingBatch}}
-          <a id="loadmore-trigger" disabled="disabled" href="{{nextPagePath}}" class="btn btn-default btn-lg" name="startdate">Loading more…<span class="loading">&nbsp;</span></a>
+          <a id="loadmore-trigger" disabled="disabled" href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Loading more…<span class="loading">&nbsp;</span></a>
         {{else}}
-          <a id="loadmore-trigger" href="{{nextPagePath}}" class="btn btn-default btn-lg" name="startdate">Load more…</a>
+          <a id="loadmore-trigger" href="javascript:void(0);" class="btn btn-default btn-lg" name="startdate">Load more…</a>
         {{/if}}
         {{#if error}}
           <div class="alert alert-danger fade in"><a href="#" class="close" data-dismiss="alert">&times;</a> Could not load more posts. Please try again</div>
@@ -196,13 +196,25 @@
 {%- endblock -%}
 
 {%- block footerscripts -%}
-  {%- if loadmore and paginated %}
-    <script type="text/javascript">
-      window.Hasjob.Loadmore.update({
-        nextPagePath: '{{request.path + '?' + 'startdate=' + loadmore.isoformat() + 'Z' + '&' + request.query_string if loadmore else False}}'
-      });
+  {%- if loadmore -%}
+    {%- if not paginated -%}
+      <script type="text/javascript">
+        $(function() {
+          window.Hasjob.Loadmore.init({
+            timestamp: '{{loadmore.isoformat()}}Z'
+          });
+        });
+      </script>
+    {%- else -%}
+      <script type="text/javascript">
+        $(function() {
+          window.Hasjob.Loadmore.update({
+            timestamp: '{{loadmore.isoformat()}}Z'
+          });
+        });
     </script>
-  {%- endif %}
+    {%- endif -%}
+  {%- endif -%}
   {%- if not paginated -%}
     {% from "macros.html" import filters_setup_script %}
     {%- if request.is_xhr -%}
@@ -210,9 +222,6 @@
     {%- endif %}
     <script type="text/javascript">
       $(function() {
-        window.Hasjob.Loadmore.init({
-          nextPagePath: '{{request.path + '?' + 'startdate=' + loadmore.isoformat() + 'Z' + '&' + request.query_string if loadmore else False}}'
-        });
         //For setting the pay slider
         window.Hasjob.PayFilterParameters = {
           'currency': {{ request.args.get('currency') | tojson }},

--- a/hasjob/templates/layout.html
+++ b/hasjob/templates/layout.html
@@ -40,7 +40,9 @@
     }
     // Use Hasjob.Config for server-generated responses
     if (typeof window.Hasjob.Config === 'undefined') {
-      window.Hasjob.Config = {}
+      window.Hasjob.Config = {
+        baseURL: "/"
+      }
     }
   </script>
   {%- if not paginated -%}

--- a/hasjob/views/helper.py
+++ b/hasjob/views/helper.py
@@ -719,14 +719,3 @@ def inject_filter_options():
     return dict(job_location_filters=filter_locations(filters),
                 job_type_filters=filter_types(basequery, board=g.board, filters=filters),
                 job_category_filters=filter_categories(basequery, board=g.board, filters=filters))
-
-
-@app.context_processor
-def format_args():
-    def inner(loadmore):
-        if not loadmore:
-            return loadmore
-        args = dict(request.args)
-        args.update({'startdate': loadmore})
-        return args
-    return dict(format_args=inner)

--- a/hasjob/views/helper.py
+++ b/hasjob/views/helper.py
@@ -719,3 +719,14 @@ def inject_filter_options():
     return dict(job_location_filters=filter_locations(filters),
                 job_type_filters=filter_types(basequery, board=g.board, filters=filters),
                 job_category_filters=filter_categories(basequery, board=g.board, filters=filters))
+
+
+@app.context_processor
+def format_args():
+    def inner(loadmore):
+        if not loadmore:
+            return loadmore
+        args = dict(request.args)
+        args.update({'startdate': loadmore})
+        return args
+    return dict(format_args=inner)

--- a/hasjob/views/index.py
+++ b/hasjob/views/index.py
@@ -293,16 +293,24 @@ def index(basequery=None, type=None, category=None, md5sum=None, domain=None,
         else:
             batchsize = 32
 
+        # list of posts that were pinned at the time of first load
+        pinned_hashids = request.args.getlist('ph')
         # Depending on the display mechanism (grouped or ungrouped), extract the batch
         if grouped:
             if not startdate:
                 startindex = 0
+                for row in grouped.values():
+                    # break when a non-pinned post is encountered
+                    if (not row[0][0]):
+                        break
+                    else:
+                        pinned_hashids.append(row[0][1].hashid)
             else:
                 # Loop through group looking for start of next batch. See below to understand the
                 # nesting structure of 'grouped'
                 for startindex, row in enumerate(grouped.values()):
-                    # Skip examination of pinned listings (having row[0][0] = True)
-                    if (not row[0][0]) and row[0][1].datetime < startdate:
+                    # Skip pinned posts when looking for starting index
+                    if (row[0][1].hashid not in pinned_hashids and row[0][1].datetime < startdate):
                         break
 
             batch = grouped.items()[startindex:startindex + batchsize]
@@ -318,10 +326,16 @@ def index(basequery=None, type=None, category=None, md5sum=None, domain=None,
         elif pinsandposts:
             if not startdate:
                 startindex = 0
+                for row in pinsandposts:
+                    # break when a non-pinned post is encountered
+                    if not row[0]:
+                        break
+                    else:
+                        pinned_hashids.append(row[1].hashid)
             else:
                 for startindex, row in enumerate(pinsandposts):
                     # Skip pinned posts when looking for starting index
-                    if (not row[0]) and row[1].datetime < startdate:
+                    if (row[1].hashid not in pinned_hashids and row[1].datetime < startdate):
                         break
 
             batch = pinsandposts[startindex:startindex + batchsize]
@@ -329,7 +343,6 @@ def index(basequery=None, type=None, category=None, md5sum=None, domain=None,
                 # batch = [(pinned, post), ...]
                 loadmore = batch[-1][1].datetime
             pinsandposts = batch
-
     if grouped:
         g.impressions = {post.id: (pinflag, post.id, is_bgroup)
             for group in grouped.itervalues()
@@ -339,8 +352,7 @@ def index(basequery=None, type=None, category=None, md5sum=None, domain=None,
 
     query_params = request.args.to_dict(flat=False)
     if loadmore:
-        query_params.update({'startdate': loadmore.isoformat() + 'Z'})
-
+        query_params.update({'startdate': loadmore.isoformat() + 'Z', 'ph': pinned_hashids})
     return dict(
         pinsandposts=pinsandposts, grouped=grouped, now=now,
         newlimit=newlimit, jobtype=type, jobcategory=category, title=title,

--- a/hasjob/views/index.py
+++ b/hasjob/views/index.py
@@ -338,6 +338,7 @@ def index(basequery=None, type=None, category=None, md5sum=None, domain=None,
     elif pinsandposts:
         g.impressions = {post.id: (pinflag, post.id, is_bgroup) for pinflag, post, is_bgroup in pinsandposts}
 
+    loadmore = loadmore.isoformat() + 'Z' if loadmore else None
     return dict(
         pinsandposts=pinsandposts, grouped=grouped, now=now,
         newlimit=newlimit, jobtype=type, jobcategory=category, title=title,

--- a/hasjob/views/index.py
+++ b/hasjob/views/index.py
@@ -338,14 +338,17 @@ def index(basequery=None, type=None, category=None, md5sum=None, domain=None,
     elif pinsandposts:
         g.impressions = {post.id: (pinflag, post.id, is_bgroup) for pinflag, post, is_bgroup in pinsandposts}
 
-    loadmore = loadmore.isoformat() + 'Z' if loadmore else None
+    query_params = dict(request.args)
+    if loadmore:
+        query_params.update({'startdate': loadmore.isoformat() + 'Z'})
+
     return dict(
         pinsandposts=pinsandposts, grouped=grouped, now=now,
         newlimit=newlimit, jobtype=type, jobcategory=category, title=title,
         md5sum=md5sum, domain=domain, employer_name=employer_name,
         location=location, showall=showall, tag=tag, is_index=is_index,
         header_campaign=header_campaign, loadmore=loadmore,
-        search_domains=search_domains,
+        search_domains=search_domains, query_params=query_params,
         is_siteadmin=lastuser.has_permission('siteadmin'),
         pay_graph_data=pay_graph_data, paginated=JobPost.is_paginated(request))
 

--- a/hasjob/views/index.py
+++ b/hasjob/views/index.py
@@ -99,7 +99,6 @@ def index(basequery=None, type=None, category=None, md5sum=None, domain=None,
         is_index = True
     else:
         is_index = False
-
     now = datetime.utcnow()
     if basequery is None and not (g.user or g.kiosk or (g.board and not g.board.require_login)):
         showall = False
@@ -338,7 +337,7 @@ def index(basequery=None, type=None, category=None, md5sum=None, domain=None,
     elif pinsandposts:
         g.impressions = {post.id: (pinflag, post.id, is_bgroup) for pinflag, post, is_bgroup in pinsandposts}
 
-    query_params = dict(request.args)
+    query_params = request.args.to_dict(flat=False)
     if loadmore:
         query_params.update({'startdate': loadmore.isoformat() + 'Z'})
 


### PR DESCRIPTION
- Rewrote JavaScript for paginating posts. Briefly, this patch uses `ractive` for templating and removes the necessity for the 'ajaxForm' and `appear` plugins to be used.
- Uses `GET` instead of `POST` for pagination.
- Fixes the dropdown-closes-when-user-paginates bug.