### PR TITLE
adding sweep command under manage.py - issue #221

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from coaster.manage import init_manager, database
+from coaster.manage import init_manager, manager
 
 import hasjob
 import hasjob.models as models
@@ -11,7 +11,7 @@ from hasjob import app, init_for
 from datetime import datetime, timedelta
 from sqlalchemy.exc import IntegrityError
 
-@database.option('-e', '--env', default='dev', help="runtime env [default 'dev']")
+@manager.option('-e', '--env', default='dev', help="runtime env [default 'dev']")
 def sweep(env):
     """Sweep the user database to close all the inactive sessions"""
     manager.init_for(env)
@@ -21,7 +21,7 @@ def sweep(env):
     es.query.filter((es.ended_at==None) & (es.active_at<(datetime.utcnow() - \
         timedelta(minutes=30)))).update({es.ended_at: es.active_at})
     try:
-        db.sessions.commit()
+        db.session.commit()
     except IntegrityError:
         print "Could not commit changes made. Please try again later."
         db.session.rollback()

--- a/manage.py
+++ b/manage.py
@@ -9,6 +9,7 @@ import hasjob.views as views
 from hasjob.models import db
 from hasjob import app, init_for
 from datetime import datetime, timedelta
+from sqlalchemy.exc import IntegrityError
 
 @database.option('-e', '--env', default='dev', help="runtime env [default 'dev']")
 def sweep(env):
@@ -19,6 +20,11 @@ def sweep(env):
     # Inactive sessions are only kept for 30mins
     es.query.filter((es.ended_at==None) & (es.active_at<(datetime.utcnow() - \
         timedelta(minutes=30)))).update({es.ended_at: es.active_at})
+    try:
+        db.sessions.commit()
+    except IntegrityError:
+        print "Could not commit changes made. Please try again later."
+        db.session.rollback()
 
 
 if __name__ == '__main__':

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from coaster.manage import init_manager
+from coaster.manage import init_manager, database
 
 import hasjob
 import hasjob.models as models
@@ -8,6 +8,17 @@ import hasjob.forms as forms
 import hasjob.views as views
 from hasjob.models import db
 from hasjob import app, init_for
+from datetime import datetime, timedelta
+
+@database.option('-e', '--env', default='dev', help="runtime env [default 'dev']")
+def sweep(env):
+    """Sweep the user database to close all the inactive sessions"""
+    manager.init_for(env)
+    print "Sweeping all the inactive sessions"
+    es = models.EventSession
+    # Inactive sessions are only kept for 30mins
+    es.query.filter((es.ended_at==None) & (es.active_at<(datetime.utcnow() - \
+        timedelta(minutes=30)))).update({es.ended_at: es.active_at})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Similar to what is done in EventSession, this additional command - manage.py db sweep - can be used to close those sessions which are inactive for last 30mins.