### PR TITLE
Moved related posts to a different endpoint and showing only when user scrolls

### DIFF
--- a/hasjob/templates/detail.html
+++ b/hasjob/templates/detail.html
@@ -385,15 +385,8 @@
   {%- endif %}
 {% endblock %}
 {% block postcontent %}
-  {%- if related_posts %}
   <ul id="stickie-area" class="row">
-    {%- for post in related_posts -%}
-      <li class="col-xs-12 col-md-3 col-sm-4">
-        {{ stickie(post, post.url_for(), false, show_viewcounts=is_siteadmin or g.user and g.user.flags.is_employer_month, show_pay=is_siteadmin, starred=g.user and post.id in g.starred_ids) }}
-      </li>
-    {%- endfor -%}
   </ul>
-  {%- endif %}
 {% endblock %}
 {% block footerscripts %}
 <script type="text/javascript">
@@ -454,6 +447,23 @@
         $(this).removeAttr("disabled");
       });
       return false;
+    });
+  });
+  $(function () {
+    var triggered_related = false;
+    $(window).scroll(function() {
+      if (!triggered_related &&
+          $(window).scrollTop() >= ($('#stickie-area').position().top - $(window).height()) &&
+          ($(window).height() + $(window).scrollTop()) < $(document).height()
+      ) {
+        triggered_related = true;
+        jQuery.get(
+          window.location.pathname + '/related',
+          function (data) {
+            $('#stickie-area').html(data);
+          }
+        );
+      }
     });
   });
 </script>

--- a/hasjob/templates/detail.html
+++ b/hasjob/templates/detail.html
@@ -451,15 +451,10 @@
   });
   $(function () {
     var triggered_related = false;
-    $(window).scroll(function() {
-      if (!triggered_related &&
-          $(window).scrollTop() >= ($('#stickie-area').position().top - $(window).height()) &&
-          ($(window).height() + $(window).scrollTop()) < $(document).height()
-      ) {
+    $('#stickie-area').appear().on('appear', function(event, element) {
+      if(!triggered_related) {
         triggered_related = true;
-        jQuery.get(
-          window.location.pathname + '/related',
-          function (data) {
+        $.get(window.location.pathname + '/related', function (data) {
             $('#stickie-area').html(data);
           }
         );

--- a/hasjob/templates/detail.html
+++ b/hasjob/templates/detail.html
@@ -451,7 +451,10 @@
   });
   $(function () {
     var triggered_related = false;
-    $('#stickie-area').appear().on('appear', function(event, element) {
+    // Fetch the related posts once the given view is on the display.
+    // triggered_related is a boolean that makes sure we dont call the
+    // related posts endpoint more than once.
+    $('#apply-info').appear().on('appear', function(event, element) {
       if(!triggered_related) {
         triggered_related = true;
         $.get(window.location.pathname + '/related', function (data) {

--- a/hasjob/templates/related_posts.html
+++ b/hasjob/templates/related_posts.html
@@ -1,0 +1,8 @@
+{%- from "macros.html" import stickie %}
+{%- if related_posts %}
+  {%- for post in related_posts -%}
+    <li class="col-xs-12 col-md-3 col-sm-4">
+      {{ stickie(post, post.url_for(), false, show_viewcounts=is_siteadmin or g.user and g.user.flags.is_employer_month, show_pay=is_siteadmin, starred=g.user and post.id in g.starred_ids) }}
+    </li>
+  {%- endfor -%}
+{%- endif %}

--- a/hasjob/views/listing.py
+++ b/hasjob/views/listing.py
@@ -192,10 +192,7 @@ def jobdetail(domain, hashid):
 @app.route('/view/<hashid>/related', defaults={'domain': None}, methods=('GET', 'POST'))
 def job_related_posts(domain, hashid):
     is_siteadmin = lastuser.has_permission('siteadmin')
-    query = JobPost.query.filter_by(hashid=hashid).options(
-        db.subqueryload('locations'), db.subqueryload('taglinks'))
-
-    post = query.first_or_404()
+    post = JobPost.query.filter_by(hashid=hashid).options(*JobPost._defercols).first_or_404()
 
     jobpost_ab = session_jobpost_ab()
     related_posts = post.related_posts().all()

--- a/hasjob/views/listing.py
+++ b/hasjob/views/listing.py
@@ -190,13 +190,11 @@ def jobdetail(domain, hashid):
 @app.route('/<domain>/<hashid>/related', methods=('GET', 'POST'))
 @app.route('/view/<hashid>/related', defaults={'domain': None}, methods=('GET', 'POST'), subdomain='<subdomain>')
 @app.route('/view/<hashid>/related', defaults={'domain': None}, methods=('GET', 'POST'))
-def jobrelatedposts(domain, hashid):
+def job_related_posts(domain, hashid):
     is_siteadmin = lastuser.has_permission('siteadmin')
     query = JobPost.query.filter_by(hashid=hashid).options(
         db.subqueryload('locations'), db.subqueryload('taglinks'))
-    # if g.user:
-    #     query = query.outerjoin(UserJobView,
-    #         db.and_(UserJobView.user_id == g.user.id, UserJobView.jobpost_id == JobPost.id))
+
     post = query.first_or_404()
 
     jobpost_ab = session_jobpost_ab()

--- a/hasjob/views/listing.py
+++ b/hasjob/views/listing.py
@@ -185,11 +185,10 @@ def jobdetail(domain, hashid):
         )
 
 
-@csrf.exempt
-@app.route('/<domain>/<hashid>/related', methods=('GET', 'POST'), subdomain='<subdomain>')
-@app.route('/<domain>/<hashid>/related', methods=('GET', 'POST'))
-@app.route('/view/<hashid>/related', defaults={'domain': None}, methods=('GET', 'POST'), subdomain='<subdomain>')
-@app.route('/view/<hashid>/related', defaults={'domain': None}, methods=('GET', 'POST'))
+@app.route('/<domain>/<hashid>/related', subdomain='<subdomain>')
+@app.route('/<domain>/<hashid>/related')
+@app.route('/view/<hashid>/related', defaults={'domain': None}, subdomain='<subdomain>')
+@app.route('/view/<hashid>/related', defaults={'domain': None})
 def job_related_posts(domain, hashid):
     is_siteadmin = lastuser.has_permission('siteadmin')
     post = JobPost.query.filter_by(hashid=hashid).options(*JobPost._defercols).first_or_404()

--- a/hasjob/views/listing.py
+++ b/hasjob/views/listing.py
@@ -174,21 +174,39 @@ def jobdetail(domain, hashid):
     else:
         g.starred_ids = set()
 
-    jobpost_ab = session_jobpost_ab()
-    related_posts = post.related_posts().all()
-    if is_siteadmin or (g.user and g.user.flags.get('is_employer_month')):
-        cache_viewcounts(related_posts)
     is_bgroup = getbool(request.args.get('b'))
     headline = post.headlineb if is_bgroup and post.headlineb else post.headline
-    g.impressions = {rp.id: (False, rp.id, bgroup(jobpost_ab, rp)) for rp in related_posts}
 
     return render_template('detail.html', post=post, headline=headline, reportform=reportform, rejectform=rejectform,
         pinnedform=pinnedform, applyform=applyform, job_application=job_application,
         jobview=jobview, report=report, moderateform=moderateform,
         domain_mismatch=domain_mismatch, header_campaign=header_campaign,
-        related_posts=related_posts, is_bgroup=is_bgroup,
-        is_siteadmin=is_siteadmin
+        is_bgroup=is_bgroup, is_siteadmin=is_siteadmin
         )
+
+
+@csrf.exempt
+@app.route('/<domain>/<hashid>/related', methods=('GET', 'POST'), subdomain='<subdomain>')
+@app.route('/<domain>/<hashid>/related', methods=('GET', 'POST'))
+@app.route('/view/<hashid>/related', defaults={'domain': None}, methods=('GET', 'POST'), subdomain='<subdomain>')
+@app.route('/view/<hashid>/related', defaults={'domain': None}, methods=('GET', 'POST'))
+def jobrelatedposts(domain, hashid):
+    is_siteadmin = lastuser.has_permission('siteadmin')
+    query = JobPost.query.filter_by(hashid=hashid).options(
+        db.subqueryload('locations'), db.subqueryload('taglinks'))
+    # if g.user:
+    #     query = query.outerjoin(UserJobView,
+    #         db.and_(UserJobView.user_id == g.user.id, UserJobView.jobpost_id == JobPost.id))
+    post = query.first_or_404()
+
+    jobpost_ab = session_jobpost_ab()
+    related_posts = post.related_posts().all()
+    if is_siteadmin or (g.user and g.user.flags.get('is_employer_month')):
+        cache_viewcounts(related_posts)
+    g.impressions = {rp.id: (False, rp.id, bgroup(jobpost_ab, rp)) for rp in related_posts}
+
+    return render_template('related_posts.html', post=post,
+        related_posts=related_posts, is_siteadmin=is_siteadmin)
 
 
 @app.route('/<domain>/<hashid>/star', defaults={'domain': None}, methods=['POST'], subdomain='<subdomain>')


### PR DESCRIPTION
Fixes #338.

Now once the user is on a job details page, the related job posts will be loaded only when the user scrolls to the `#stickie-area` div, not before.