### PR TITLE
Cache session active_at in Redis for periodic job processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Some functionality in Hasjob requires the presence of a sub-board named `www`. C
 
 Hasjob requires some tasks to be run in periodic background jobs. These can be called from cron. Use `crontab -e` as the user account running Hasjob and add:
 
-    */10 * * * * cd /path/to/hasjob; python manage.py periodic sessions -e dev
+    */5 * * * * cd /path/to/hasjob; python manage.py periodic sessions -e dev
     */5  * * * * cd /path/to/hasjob; python manage.py periodic impressions -e dev
 
 Switch from `dev` to `production` in a production environment.


### PR DESCRIPTION
This branch introduces two new patterns that need some discussion and consensus on:

1. Models that store frequently changing data (like `active_at` timestamps) in Redis, for periodic job processors to flush to database. Should we override the column property to transparently write to Redis instead of custom code each time? Should the flush to db have a standardised name like say `flush_from_redis`?
2. Models that use UUID keys and must expect queries with either UUID or string parameters. Where exactly is type safety enforced?