### PR TITLE
Use UuidMixin. Fixes #398.

### DIFF
--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -14,6 +14,7 @@ from alembic import op
 import sqlalchemy as sa
 ${imports if imports else ""}
 
+
 def upgrade():
     ${upgrades if upgrades else "pass"}
 

--- a/migrations/versions/a55bb6a85c83_use_uuidmixin.py
+++ b/migrations/versions/a55bb6a85c83_use_uuidmixin.py
@@ -1,0 +1,54 @@
+"""Use UuidMixin
+
+Revision ID: a55bb6a85c83
+Revises: 15aede1ebe6f
+Create Date: 2017-07-13 14:23:03.655538
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'a55bb6a85c83'
+down_revision = '15aede1ebe6f'
+
+from uuid import uuid4
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import table, column
+from sqlalchemy_utils import UUIDType
+from progressbar import ProgressBar
+import progressbar.widgets
+
+event_session = table('event_session',
+    column('id', sa.Integer()),
+    column('uuid', UUIDType(binary=False)),
+    )
+
+
+def get_progressbar(label, maxval):
+    return ProgressBar(maxval=maxval,
+        widgets=[
+            label, ': ',
+            progressbar.widgets.Percentage(), ' ',
+            progressbar.widgets.Bar(), ' ',
+            progressbar.widgets.ETA(), ' '
+            ])
+
+
+def upgrade():
+    conn = op.get_bind()
+    count = conn.scalar(
+        sa.select(
+            [sa.func.count('*')]
+            ).select_from(event_session).where(event_session.c.uuid == None))  # NOQA
+    progress = get_progressbar("UUIDs", count)
+    progress.start()
+    items = conn.execute(sa.select([event_session.c.id]).where(event_session.c.uuid == None))  # NOQA
+    for counter, item in enumerate(items):
+        conn.execute(sa.update(event_session).where(event_session.c.id == item.id).values(uuid=uuid4()))
+        progress.update(counter)
+    progress.finish()
+    op.alter_column('event_session', 'uuid', existing_type=UUIDType(binary=False), nullable=False)
+
+
+def downgrade():
+    op.alter_column('event_session', 'uuid', existing_type=UUIDType(binary=False), nullable=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ git+https://github.com/hasgeek/coaster
 git+https://github.com/hasgeek/flask-lastuser
 git+https://github.com/hasgeek/baseframe
 Flask-Migrate
+progressbar2


### PR DESCRIPTION
Inserts random UUIDs into old sessions that didn’t have a UUID (a bug)