### PR TITLE
Added post headline in confirmation mail subject

### DIFF
--- a/hasjob/views/listing.py
+++ b/hasjob/views/listing.py
@@ -686,7 +686,7 @@ def confirm(domain, hashid):
     # We get here if it's (a) POST_STATE.UNPUBLISHED and (b) the user is confirmed authorised
     if 'form.id' in request.form and form.validate_on_submit():
         # User has accepted terms of service. Now send email and/or wait for payment
-        msg = Message(subject="Confirm your job post: \"{headline}\"".format(headline=post.headline),
+        msg = Message(subject="Confirm your job post: {headline}".format(headline=post.headline),
             recipients=[post.email])
         msg.html = email_transform(render_template('confirm_email.html.jinja2', post=post), base_url=request.url_root)
         msg.body = html2text(msg.html)

--- a/hasjob/views/listing.py
+++ b/hasjob/views/listing.py
@@ -686,7 +686,7 @@ def confirm(domain, hashid):
     # We get here if it's (a) POST_STATE.UNPUBLISHED and (b) the user is confirmed authorised
     if 'form.id' in request.form and form.validate_on_submit():
         # User has accepted terms of service. Now send email and/or wait for payment
-        msg = Message(subject="Confirmation of your job post at Hasjob",
+        msg = Message(subject="Confirm your job post at Hasjob - \"{headline}\"".format(headline=post.headline),
             recipients=[post.email])
         msg.html = email_transform(render_template('confirm_email.html.jinja2', post=post), base_url=request.url_root)
         msg.body = html2text(msg.html)

--- a/hasjob/views/listing.py
+++ b/hasjob/views/listing.py
@@ -686,7 +686,7 @@ def confirm(domain, hashid):
     # We get here if it's (a) POST_STATE.UNPUBLISHED and (b) the user is confirmed authorised
     if 'form.id' in request.form and form.validate_on_submit():
         # User has accepted terms of service. Now send email and/or wait for payment
-        msg = Message(subject="Confirm your job post at Hasjob - \"{headline}\"".format(headline=post.headline),
+        msg = Message(subject="Confirm your job post: \"{headline}\"".format(headline=post.headline),
             recipients=[post.email])
         msg.html = email_transform(render_template('confirm_email.html.jinja2', post=post), base_url=request.url_root)
         msg.body = html2text(msg.html)


### PR DESCRIPTION
Right now all job post confirmation mails have same subject line, which makes mail clients like Gmail to show them as threads. And if there are similar looking lines, Gmail sometimes even quotes the same lines which makes it hard to distinguish between confirmation mails of multiple job posts posted close to each other.

Adding the post headline to subject helps prevent that. With this PR, this is how the subject line will look like -

> Subject: Confirm your job post at Hasjob - "A test job post"