### PR TITLE
Catch invalid values in isoformat datetime

### DIFF
--- a/hasjob/views/index.py
+++ b/hasjob/views/index.py
@@ -397,7 +397,7 @@ def fetch_jobposts(
                 startdate = parse_isoformat(
                     request_values['startdate'].upper(), naive=False
                 )
-            except ParseError:
+            except (ParseError, ValueError):
                 abort(400)
 
         batchsize = 32


### PR DESCRIPTION
Sample string 'KKVJQAMDK' causes a ValueError in downstream library aniso8601 from this line:

`isodatestr, isotimestr = isodatetimestr.split(delimiter, 1)`